### PR TITLE
feat: Add --transcript-only argument to output raw transcript instead of summary

### DIFF
--- a/summarizer/extension.py
+++ b/summarizer/extension.py
@@ -46,7 +46,7 @@ def summarize(msg):
     ctx = msg['ctx']
     config = load_config()
     result = process_video(
-        ProgressHooks(ctx), video_url=msg['url'], **config
+        ProgressHooks(ctx), video_url=msg['url'], transcript_only=True, **config
     )
     filename = f'{OUT_DIR}/{result.video_id}.html'
     os.makedirs(OUT_DIR, exist_ok = True)

--- a/summarizer/summarizer.py
+++ b/summarizer/summarizer.py
@@ -372,6 +372,7 @@ def process_video(progress_hooks, video_url, *,
                   force_local_transcribe = False,
                   verbose = False,
                   add_openai_profile = [],
+                  transcript_only = False,
                   **kwargs):
     with TemporaryDirectory() as tmpdir:
         info = {
@@ -399,6 +400,10 @@ def process_video(progress_hooks, video_url, *,
     video_id = video_info['id']
     if video_info['extractor'].startswith('youtube'):
         captions = remove_sponsored(video_id, sponsorblock, captions)
+
+    if transcript_only:
+        transcript = "\n".join([c.text for c in captions])
+        return ProcessResult(video_id, transcript)
 
     sections = sectionize_captions(captions, duration)
     if duration > 3600 and duration % 3600 < 60:


### PR DESCRIPTION
Added --transcript-only argument to command-line. When used, this argument instructs the tool to return the raw transcribed text instead of the summary.

**Motivation:**
This feature provides a more lightweight alternative for users who only need the text transcript of a video, without the computationally intensive LLM summarization step. This can be useful for archiving, analysis, or other purposes where the raw text is sufficient.

**Changes:**

- summarizer/summarizer.py:
  - Added a transcript_only argument to the process_video function.
  - Implemented conditional logic: if transcript_only is True, the function concatenates the captions and returns the resulting transcript. The rest of the function, including LLM Summarization, is skipped.
- summarizer/cli.py:
  - Added a --transcript-only argument to the command-line interface using argparse.
  - The text returned is saved into the out folder instead of the original webpage.
- summarizer/extension.py
  - transcript_only argument has been implemented in browser extension.
